### PR TITLE
Add details to sent message confirmations

### DIFF
--- a/Contexe.py
+++ b/Contexe.py
@@ -186,13 +186,15 @@ async def on_message(message):
                                     serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                      ' was sent a Valentine (:heart:) from ' +
                                                                      sender[0] + ' ' + sender[1] + '.')
-                                    await channel.send("Message sent.")
+                                    await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                       ' a Valentine (:heart:) from ' + sender[0] + ' ' + sender[1] + '.')
                                     
                                 elif sender:
                                     serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                      ' was sent a Rejection (:x:) from ' +
                                                                      sender[0] + ' ' + sender[1] + '.')
-                                    await channel.send("Message sent.")
+                                    await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                       ' a Rejection (:x:) from ' + sender[0] + ' ' + sender[1] + '.')
                                     
                                 else:
                                     # if the player put something in the sender field that wasn't found,
@@ -204,13 +206,15 @@ async def on_message(message):
                                     serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                      ' was sent a Valentine (:heart:) ' +
                                                                      'from an anonymous admirer.')
-                                    await channel.send("Message sent.")
+                                    await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                       ' a Valentine (:heart:) from an anonymous admirer.')
                                     
                                 else:
                                     serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                      ' was sent a Rejection (:x:) from ' +
                                                                      'an anonymous opponent.')
-                                    await channel.send("Message sent.")
+                                    await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                       ' a Rejection (:x:) from an anonymous opponent.')
                             
                         elif command[3] in RINGS + SKULLS:
                             # the last round behaves differently, and we no longer need player input for the sender
@@ -220,12 +224,14 @@ async def on_message(message):
                                 serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                  ' was sent a Proposal (:ring:) from '
                                                                  + sender[0] + ' ' + sender[1] + '.')
-                                await channel.send("Message sent.")
+                                await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                   ' a Proposal (:ring:) from ' + sender[0] + ' ' + sender[1] + '.')
                                 
                             elif sender:
                                 serverdata[command[1]][1].append(recipient[0] + ' ' + recipient[1] +
                                                                  ' was sent an Assassination (:skull:).')
-                                await channel.send("Message sent.")
+                                await channel.send('Sent ' + recipient[0] + ' ' + recipient[1] +
+                                                   ' an Assassination (:skull:).')
                                 
                             else:
                                 # i don't anticipate this'll happen often, but it's good to have


### PR DESCRIPTION
Addressing #3 -- add details when a message is sent so it is more clear that the user sent the message they intended to.